### PR TITLE
maint: Push docker image to ecr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           command: echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
       - run:
           name: Push Multi-Arch Docker Image
-          command: |            
+          command: |
             docker buildx build \
               --platform linux/amd64,linux/arm64 \
               --sbom=true \
@@ -103,7 +103,6 @@ jobs:
               -t honeycombio/supervised-collector:$CIRCLE_SHA1 \
               -t honeycombio/supervised-collector:latest \
               .
-
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  docker: circleci/docker@2.8.2
+  aws-cli: circleci/aws-cli@3.2.0
 
 executors:
   docker-executor:
@@ -17,6 +17,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           privileged: true  # Required for Buildx
+          docker_layer_caching: true
       - run:
           no_output_timeout: 30m
           name: Set up Docker Buildx
@@ -32,13 +33,56 @@ jobs:
             docker buildx build \
               --platform linux/amd64,linux/arm64 \
               .
-  build-and-push-multiarch:
+  publish-multiarch-to-ecr:
     executor: docker-executor
     resource_class: xlarge
     steps:
       - checkout
       - setup_remote_docker:
           privileged: true  # Required for Buildx
+          docker_layer_caching: true
+      - run:
+          no_output_timeout: 30m
+          name: Set up Docker Buildx
+          command: |
+            docker buildx create --use --name multiarch_builder
+            docker buildx inspect --bootstrap  # Ensures everything is set up correctly
+      - aws-cli/setup:
+          role-arn: "arn:aws:iam::017118846235:role/circleci-sandbox-telemetry"
+          role-session-name: "supervised-collector"
+          aws-region: AWS_REGION
+      - run:
+          name: Login to ECR
+          command: |
+            set -x
+
+            export ECR_HOST=017118846235.dkr.ecr.us-east-1.amazonaws.com
+
+            aws ecr get-login-password --region us-east-1 \
+              | docker login --username AWS --password-stdin "${ECR_HOST}"
+      - run:
+          name: Push Multi-Arch Docker Image
+          command: |
+            VERSION_FROM_GIT=$(git describe --tags --match='v[0-9]*' --always)
+            VERSION_FROM_GIT=${VERSION_FROM_GIT#'v'}
+            
+            docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              --sbom=true \
+              --provenance=true \
+              --push \
+              -t 017118846235.dkr.ecr.us-east-1.amazonaws.com/supervised-collector:$CIRCLE_SHA1 \
+              -t 017118846235.dkr.ecr.us-east-1.amazonaws.com/supervised-collector:$VERSION_FROM_GIT \
+              .
+
+  publish-multiarch-to-dockerhub:
+    executor: docker-executor
+    resource_class: xlarge
+    steps:
+      - checkout
+      - setup_remote_docker:
+          privileged: true  # Required for Buildx
+          docker_layer_caching: true
       - run:
           no_output_timeout: 30m
           name: Set up Docker Buildx
@@ -49,8 +93,8 @@ jobs:
           name: Login to Docker Hub
           command: echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
       - run:
-          name: Build and Push Multi-Arch Docker Image
-          command: |
+          name: Push Multi-Arch Docker Image
+          command: |            
             docker buildx build \
               --platform linux/amd64,linux/arm64 \
               --sbom=true \
@@ -59,6 +103,7 @@ jobs:
               -t honeycombio/supervised-collector:$CIRCLE_SHA1 \
               -t honeycombio/supervised-collector:latest \
               .
+
 
 workflows:
   version: 2
@@ -69,8 +114,19 @@ workflows:
           filters:
             tags:
               ignore: /^v.*/
-      - build-and-push-multiarch:
+      - publish-multiarch-to-ecr:
           context: Honeycomb Secrets for Public Repos
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /pull\/.*/
+      - publish-multiarch-to-dockerhub:
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - build
           filters:
             tags:
               only: /^v.*/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# GoLand IDEA
+/.idea/
+/.run/
+*.iml
+
+# VS Code
+.vscode/
+.devcontainer/
+
+# Emacs
+*~
+\#*\#
+
+# Miscellaneous files
+*.sw[op]
+*.DS_Store
+
+# Coverage
+coverage.out
+coverage.txt
+coverage.html
+
+# cache for ko-build/
+ko-cache/
+ko
+ko*.tar.gz
+
+# build output directory
+bin
+
+# test results directory
+test_results
+
+# used by opampsupervisor example
+otelcol-contrib
+output/*


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes https://github.com/honeycombio/pipeline-team/issues/237

## Short description of the changes

Update ci to push images to private ecr for testing, like we do with refinery.

## How to verify that this has the expected result

Circleci tests on the branch.
