### PR TITLE
feat: publish docker images to GHCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,31 @@ jobs:
               honeycombio/supervised-collector:$CIRCLE_SHA1-amd64 \
               honeycombio/supervised-collector:$CIRCLE_SHA1-arm64
 
+  publish_docker_to_ghcr:
+    executor: docker-executor
+    steps:
+      - setup-docker-ecr-login
+      - run:
+          name: Login to GitHub Container Registry
+          command: echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_USERNAME --password-stdin
+      - run:
+          name: Pull from ECR and Push
+          command: |
+            docker pull --platform linux/arm64 017118846235.dkr.ecr.us-east-1.amazonaws.com/supervised-collector:$CIRCLE_SHA1-arm64
+            docker tag 017118846235.dkr.ecr.us-east-1.amazonaws.com/supervised-collector:$CIRCLE_SHA1-arm64 ghcr.io/honeycombio/supervised-collector:$CIRCLE_SHA1-arm64
+            docker push ghcr.io/honeycombio/supervised-collector:$CIRCLE_SHA1-arm64
+            docker pull --platform linux/amd64 017118846235.dkr.ecr.us-east-1.amazonaws.com/supervised-collector:$CIRCLE_SHA1-amd64
+            docker tag 017118846235.dkr.ecr.us-east-1.amazonaws.com/supervised-collector:$CIRCLE_SHA1-amd64 ghcr.io/honeycombio/supervised-collector:$CIRCLE_SHA1-amd64
+            docker push ghcr.io/honeycombio/supervised-collector:$CIRCLE_SHA1-amd64
+      - run:
+          name: Build and Push Multi-Arch Docker Image
+          command: |
+            docker buildx imagetools create \
+              -t ghcr.io/honeycombio/supervised-collector:$CIRCLE_TAG \
+              -t ghcr.io/honeycombio/supervised-collector:latest \
+              ghcr.io/honeycombio/supervised-collector:$CIRCLE_SHA1-arm64 \
+              ghcr.io/honeycombio/supervised-collector:$CIRCLE_SHA1-amd64
+
 workflows:
   version: 2
   build:
@@ -132,6 +157,15 @@ workflows:
             branches:
               ignore: /pull\/.*/
       - publish_docker_to_dockerhub:
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - publish_docker_to_ecr
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - publish_docker_to_ghcr:
           context: Honeycomb Secrets for Public Repos
           requires:
             - publish_docker_to_ecr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,12 @@ jobs:
             - run:
                 name: Login to Docker Hub
                 command: echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
+            - run:
+                name: Export GitHub Container Registry tag
+                command: echo "export GHCR_TAG=\"-t ghcr.io/honeycombio/supervised-collector:${CIRCLE_SHA1}-arm64\"" >> $BASH_ENV
+            - run:
+                name: Login to GitHub Container Registry
+                command: echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_USERNAME --password-stdin
       - run:
           name: Build Docker Image (arm64)
           command: |
@@ -57,6 +63,7 @@ jobs:
               --push \
               -t 017118846235.dkr.ecr.us-east-1.amazonaws.com/supervised-collector:${CIRCLE_SHA1}-arm64 \
               ${DOCKERHUB_TAG} \
+              ${GHCR_TAG} \
               .
   build_docker_amd64:
     executor: docker-executor
@@ -72,6 +79,12 @@ jobs:
             - run:
                 name: Login to Docker Hub
                 command: echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
+            - run:
+                name: Export GitHub Container Registry tag
+                command: echo "export GHCR_TAG=\"-t ghcr.io/honeycombio/supervised-collector:${CIRCLE_SHA1}-amd64\"" >> $BASH_ENV
+            - run:
+                name: Login to GitHub Container Registry
+                command: echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_USERNAME --password-stdin
       - run:
           name: Build Docker Image (amd64)
           command: |
@@ -82,6 +95,7 @@ jobs:
               --push \
               -t 017118846235.dkr.ecr.us-east-1.amazonaws.com/supervised-collector:${CIRCLE_SHA1}-amd64 \
               ${DOCKERHUB_TAG} \
+              ${GHCR_TAG} \
               .
   publish_docker_to_ecr:
     executor: docker-executor
@@ -124,15 +138,6 @@ jobs:
       - run:
           name: Login to GitHub Container Registry
           command: echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_USERNAME --password-stdin
-      - run:
-          name: Pull from ECR and Push
-          command: |
-            docker pull --platform linux/arm64 017118846235.dkr.ecr.us-east-1.amazonaws.com/supervised-collector:$CIRCLE_SHA1-arm64
-            docker tag 017118846235.dkr.ecr.us-east-1.amazonaws.com/supervised-collector:$CIRCLE_SHA1-arm64 ghcr.io/honeycombio/supervised-collector:$CIRCLE_SHA1-arm64
-            docker push ghcr.io/honeycombio/supervised-collector:$CIRCLE_SHA1-arm64
-            docker pull --platform linux/amd64 017118846235.dkr.ecr.us-east-1.amazonaws.com/supervised-collector:$CIRCLE_SHA1-amd64
-            docker tag 017118846235.dkr.ecr.us-east-1.amazonaws.com/supervised-collector:$CIRCLE_SHA1-amd64 ghcr.io/honeycombio/supervised-collector:$CIRCLE_SHA1-amd64
-            docker push ghcr.io/honeycombio/supervised-collector:$CIRCLE_SHA1-amd64
       - run:
           name: Build and Push Multi-Arch Docker Image
           command: |


### PR DESCRIPTION
## Which problem is this PR solving?

Updates CI scripts to also publish docker images to GHCR. The Github username and access token are stored in CircleCI secrets that are injected as environment variables.

## Short description of the changes
- add new publish action to circleci config