### PR TITLE
maint: Revert "maint: Update GHCR image paths (#8)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
                 command: echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
             - run:
                 name: Export GitHub Container Registry tag
-                command: echo "export GHCR_TAG=\"-t ghcr.io/honeycombio/supervised-collector/supervised-collector:${CIRCLE_SHA1}-arm64\"" >> $BASH_ENV
+                command: echo "export GHCR_TAG=\"-t ghcr.io/honeycombio/supervised-collector:${CIRCLE_SHA1}-arm64\"" >> $BASH_ENV
             - run:
                 name: Login to GitHub Container Registry
                 command: echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_USERNAME --password-stdin
@@ -81,7 +81,7 @@ jobs:
                 command: echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
             - run:
                 name: Export GitHub Container Registry tag
-                command: echo "export GHCR_TAG=\"-t ghcr.io/honeycombio/supervised-collector/supervised-collector:${CIRCLE_SHA1}-amd64\"" >> $BASH_ENV
+                command: echo "export GHCR_TAG=\"-t ghcr.io/honeycombio/supervised-collector:${CIRCLE_SHA1}-amd64\"" >> $BASH_ENV
             - run:
                 name: Login to GitHub Container Registry
                 command: echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_USERNAME --password-stdin
@@ -142,10 +142,10 @@ jobs:
           name: Build and Push Multi-Arch Docker Image
           command: |
             docker buildx imagetools create \
-              -t ghcr.io/honeycombio/supervised-collector/supervised-collector:$CIRCLE_TAG \
-              -t ghcr.io/honeycombio/supervised-collector/supervised-collector:latest \
-              ghcr.io/honeycombio/supervised-collector/supervised-collector:$CIRCLE_SHA1-arm64 \
-              ghcr.io/honeycombio/supervised-collector/supervised-collector:$CIRCLE_SHA1-amd64
+              -t ghcr.io/honeycombio/supervised-collector:$CIRCLE_TAG \
+              -t ghcr.io/honeycombio/supervised-collector:latest \
+              ghcr.io/honeycombio/supervised-collector:$CIRCLE_SHA1-arm64 \
+              ghcr.io/honeycombio/supervised-collector:$CIRCLE_SHA1-amd64
 
 workflows:
   version: 2


### PR DESCRIPTION
## Which problem is this PR solving?

Reverts the GHCR path used to publish the docker images. They don't need the repo name as part of the path.

Docker images want to be published to [honeycombio/supervised-collector](https://github.com/orgs/honeycombio/packages/container/package/supervised-collector).

## Short description of the changes

- Removes the repo name segment of the path to publish the images