### PR TITLE
chore: bump collector deps to 0.127.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src
 ENV CGO_ENABLED=0
 
 ADD ./builder-config.yaml ./
-RUN go install go.opentelemetry.io/collector/cmd/builder@v0.126.0
+RUN go install go.opentelemetry.io/collector/cmd/builder@v0.127.0
 RUN builder --config builder-config.yaml
 
 # use the official upstream image for the opampsupervisor

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -2,61 +2,62 @@ dist:
   module: github.com/honeycombio/opentelemetry-collector-configs
   name: supervised-collector
   description: Supervised Collector
-  version: 0.0.6
+  version: 0.0.7
   output_path: ./supervised-collector
 
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension v0.126.0
-  - gomod: github.com/honeycombio/opentelemetry-collector-configs/honeycombextension v0.0.0-20250410221110-cecf1a6cce31
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension v0.127.0
+  - gomod: github.com/honeycombio/opentelemetry-collector-configs/honeycombextension v0.0.0-20250529172854-29e92f8bd7cb
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.126.0
-  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.126.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.126.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.126.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.127.0
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.127.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.127.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.127.0
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.126.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor v0.126.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.127.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.123.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.126.0
-  - gomod: github.com/honeycombio/opentelemetry-collector-configs/usageprocessor v0.0.0-20250410221110-cecf1a6cce31
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.127.0
+  - gomod: github.com/honeycombio/opentelemetry-collector-configs/usageprocessor v0.0.0-20250529172854-29e92f8bd7cb
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.126.0
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver v0.126.0
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.127.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver v0.127.0
 
 connectors:
-  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.126.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.126.0
+  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.127.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.32.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.32.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.126.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.33.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.33.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.33.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.33.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.33.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.127.0
 
 # When using `make genotelcontribcol`, a `replaces` section is appended to this
 # file before passing it to OCB, to ensure that local versions are used for all
 # Contrib modules.
 replaces:
-  - github.com/honeycombio/opentelemetry-collector-configs/usageprocessor => github.com/honeycombio/opentelemetry-collector-configs/usageprocessor v0.0.0-20250410221110-cecf1a6cce31
+  - github.com/honeycombio/opentelemetry-collector-configs/usageprocessor => github.com/honeycombio/opentelemetry-collector-configs/usageprocessor v0.0.0-20250529172854-29e92f8bd7cb
   - github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api v0.0.0-20180801171038-322a19404e37
+  - go.opentelemetry.io/collector/service => go.opentelemetry.io/collector/service v0.127.1-0.20250528155941-4a3717978a51


### PR DESCRIPTION
This bumps dependencies to the latest release.
