### PR TITLE
feat: Add collector contrib Attributes processor to build manifest

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -21,6 +21,7 @@ exporters:
 
 processors:
   - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.128.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.128.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.128.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor v0.128.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.128.0


### PR DESCRIPTION
## Which problem is this PR solving?

Adds the OTel Collector contrib [Attributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor) that can be used to remove attributes based on a name or regular expression,

- Supports https://github.com/honeycombio/pipeline-team/issues/438

## Short description of the changes
- Add attributes processor to build manifest
