### PR TITLE
feat: add default configuration files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ USER ${USER_UID}:${USER_GID}
 
 COPY --from=opampsupervisor --chmod=755 /usr/local/bin/opampsupervisor /opampsupervisor
 COPY --from=build --chmod=755 /go/src/supervised-collector/supervised-collector /honeycomb-otelcol
+COPY ./config/agent.yaml /etc/agent.yaml
+COPY ./config/opampsupervisor.yaml /etc/opampsupervisor.yaml
 
 WORKDIR /var/lib/otelcol/supervisor
 ENTRYPOINT ["/opampsupervisor"]

--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -1,0 +1,22 @@
+service:
+  telemetry:
+    metrics:
+      readers:
+        - periodic:
+            exporter:
+              otlp:
+                endpoint: ${env:HONEYCOMB_API}
+                headers:
+                  x-honeycomb-dataset: primary-collector-metrics
+                  x-honeycomb-team: ${env:HONEYCOMB_API_KEY}
+                protocol: http/protobuf
+    logs:
+      encoding: json
+      processors:
+        - batch:
+            exporter:
+              otlp:
+                endpoint: ${env:HONEYCOMB_API}
+                headers:
+                  x-honeycomb-team: ${env:HONEYCOMB_API_KEY}
+                protocol: http/protobuf

--- a/config/opampsupervisor.yaml
+++ b/config/opampsupervisor.yaml
@@ -1,0 +1,48 @@
+server:
+  endpoint: ${OPAMP_ENDPOINT}
+  tls:
+    insecure_skip_verify: true
+    insecure: true
+
+capabilities:
+  reports_effective_config: true
+  reports_own_metrics: true
+  reports_health: true
+  accepts_remote_config: true
+  reports_remote_config: true
+
+agent:
+  executable: /honeycomb-otelcol
+  config_apply_timeout: 5s
+  config_files:
+    - /etc/agent.yaml
+  description:
+    identifying_attributes:
+      service.name: primary-collector
+      service.namespace: htp.collector
+
+storage:
+  directory: /tmp
+
+telemetry:
+  logs:
+    level: debug
+    processors:
+      - batch:
+          exporter:
+            otlp:
+              protocol: http/protobuf
+              endpoint: ${HONEYCOMB_API}
+              headers:
+                - name: "x-honeycomb-team"
+                  value: ${HONEYCOMB_API_KEY}
+  traces:
+    processors:
+      - batch:
+          exporter:
+            otlp:
+              protocol: http/protobuf
+              endpoint: ${HONEYCOMB_API}
+              headers:
+                - name: "x-honeycomb-team"
+                  value: ${HONEYCOMB_API_KEY}


### PR DESCRIPTION
## Which problem is this PR solving?

- This could be used to start the supervised collector by setting environment variables alone and not require files to be mounted in the container.

## Short description of the changes

- adds the agent and supervisor config files
- updates Dockerfile to include those files

## How to verify that this has the expected result

- start the container by passing the flag `--config=/etc/supervisor.yml`
